### PR TITLE
Ensure wrapper adapts to viewport with minimum width

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -1,6 +1,7 @@
 :root {
     --cell: 44px;
     --gap: 4px;
+    --widget-min-width: 800px;
 }
 
 * {
@@ -18,7 +19,7 @@ body {
 }
 
 .wrap {
-    width: min(980px, 94vw);
+    width: max(var(--widget-min-width), calc(100vw - 48px));
     background: rgba(255, 255, 255, .06);
     border: 1px solid rgba(255, 255, 255, .15);
     border-radius: 16px;


### PR DESCRIPTION
## Summary
- define `--widget-min-width` custom property for consistent 800px base width
- replace fixed `.wrap` width with responsive viewport-based calculation using the new variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a231134c008327bf0f65705dd4e351