### PR TITLE
Add controls breakpoint for responsive layout

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -1,6 +1,7 @@
 :root {
     --cell: 44px;
     --gap: 4px;
+    --controls-breakpoint: 500px;
 }
 
 * {
@@ -193,6 +194,16 @@ button {
 
 button.secondary {
     background: #334155;
+}
+
+@media (max-width: var(--controls-breakpoint)) {
+    .controls {
+        flex-direction: column;
+    }
+
+    button {
+        width: 100%;
+    }
 }
 
 .status {


### PR DESCRIPTION
## Summary
- add `--controls-breakpoint` variable for responsive control layout
- stack controls and expand buttons below breakpoint

## Testing
- `npm test` *(fails: ENOENT no such file or directory 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a23117d8288327a33067602a27fed3