### PR TITLE
Use variable for puzzle viewport size

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -1,6 +1,7 @@
 :root {
     --cell: 44px;
     --gap: 4px;
+    --puzzle-max-size: 520px;
 }
 
 * {
@@ -67,7 +68,7 @@ select {
 
 /* Viewport: keep scrolling/panning, but no panel look */
 .gridViewport {
-    max-width: min(520px, 94vw);
+    max-width: min(var(--puzzle-max-size), 100%);
     max-height: 520px;
     overflow: auto;
     /* no background, border, or radius so the page gradient shows through */


### PR DESCRIPTION
## Summary
- define `--puzzle-max-size` custom property for puzzle dimensions
- size `.gridViewport` with the new custom property to respect container width

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2311994948327aec2b64605a4714c