### PR TITLE
Refactor crossword CSS to use custom property constants

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -1,6 +1,7 @@
 :root {
-    --cell: 44px;
-    --gap: 4px;
+    --cell-size: 44px;
+    --gap-size: 4px;
+    --border-radius: 10px;
 }
 
 * {
@@ -48,7 +49,7 @@ select {
     background: #0f142a;
     color: #e9edff;
     border: 1px solid #2a2f45;
-    border-radius: 10px;
+    border-radius: var(--border-radius);
     padding: 8px 10px;
 }
 
@@ -83,7 +84,7 @@ select {
 /* The grid itself should also be transparent & panel-less */
 .grid {
     display: grid;
-    gap: var(--gap);
+    gap: var(--gap-size);
     /* remove panel visuals */
     background: transparent;
     border: 0;
@@ -93,8 +94,8 @@ select {
 
 /* Individual cells keep the dark style */
 .cell {
-    width: var(--cell);
-    height: var(--cell);
+    width: var(--cell-size);
+    height: var(--cell-size);
     position: relative;
     border-radius: 6px;
     border: 1px solid #2a2f45;
@@ -171,7 +172,7 @@ li {
     padding: 8px 10px;
     background: rgba(255, 255, 255, .05);
     border: 1px solid rgba(255, 255, 255, .12);
-    border-radius: 10px;
+    border-radius: var(--border-radius);
 }
 
 .controls {
@@ -185,7 +186,7 @@ button {
     background: #3b82f6;
     color: #fff;
     border: 0;
-    border-radius: 10px;
+    border-radius: var(--border-radius);
     padding: 10px 14px;
     font-weight: 700;
     cursor: pointer;
@@ -210,7 +211,7 @@ button.secondary {
 .error {
     margin-top: 10px;
     padding: 10px 12px;
-    border-radius: 10px;
+    border-radius: var(--border-radius);
     background: rgba(255, 107, 107, .1);
     border: 1px solid rgba(255, 107, 107, .35);
     color: #ffd0d0;

--- a/js/crossword.js
+++ b/js/crossword.js
@@ -162,8 +162,8 @@
     const { model, across, down, rows, cols, getCell } = built;
 
     // define grid size (rows *and* cols)
-    gridEl.style.gridTemplateColumns = `repeat(${cols}, var(--cell))`;
-    gridEl.style.gridTemplateRows    = `repeat(${rows}, var(--cell))`;
+    gridEl.style.gridTemplateColumns = `repeat(${cols}, var(--cell-size))`;
+    gridEl.style.gridTemplateRows    = `repeat(${rows}, var(--cell-size))`;
 
     // --- Highlighting state/maps
     const clueById = new Map();      // id -> <li>


### PR DESCRIPTION
## Summary
- Define reusable CSS variables for cell size, grid gap, and border radius
- Refactor crossword styles and JS to leverage the new variables for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2312204788327b6d593b4580f4ea1