### PR TITLE
Improve crossword widget responsiveness

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -23,6 +23,7 @@ body {
     color: #e9edff;
     display: grid;
     place-items: start center;
+    min-height: 100vh;
 }
 
 .wrap {
@@ -33,6 +34,10 @@ body {
     padding: 18px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, .4);
     backdrop-filter: blur(6px);
+    display: grid;
+    grid-template-rows: auto 1fr auto auto;
+    gap: 16px;
+    min-height: calc(100vh - 48px);
 }
 
 .hdr {
@@ -64,7 +69,8 @@ select {
     display: grid;
     grid-template-columns:auto 1fr;
     gap: 20px;
-    margin-top: 16px;
+    height: 100%;
+    min-height: 0;
 }
 
 @media (max-width: var(--pane-breakpoint)) {
@@ -76,12 +82,11 @@ select {
 /* Viewport: keep scrolling/panning, but no panel look */
 .gridViewport {
     max-width: min(var(--puzzle-max-size), 100%);
-    max-height: 520px;
     overflow: auto;
-    /* no background, border, or radius so the page gradient shows through */
     background: transparent;
     border: 0;
     border-radius: 0;
+    height: 100%;
 }
 
 .gridViewport.dragging {
@@ -154,6 +159,8 @@ select {
     display: grid;
     grid-template-columns:1fr 1fr;
     gap: 12px 18px;
+    overflow: auto;
+    height: 100%;
 }
 
 @media (max-width: var(--clue-breakpoint)) {
@@ -185,7 +192,6 @@ li {
 .controls {
     display: flex;
     gap: 10px;
-    margin-top: 16px;
     flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Summary
- Allow crossword area to expand with viewport height
- Stretch grid and clues sections and align controls row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2360fddf083278641e53bde051985