### PR TITLE
Use flex layout for puzzle pane

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -9,6 +9,7 @@
     --pane-breakpoint: 800px;
     --clue-breakpoint: 600px;
     --widget-min-width: 800px;
+    --pane-gap: 0px;
 }
 
 * {
@@ -69,16 +70,15 @@ select {
 }
 
 .pane {
-    display: grid;
-    grid-template-columns:auto 1fr;
-    gap: 20px;
+    display: flex;
+    gap: var(--pane-gap);
     height: 100%;
     min-height: 0;
 }
 
 @media (max-width: var(--pane-breakpoint)) {
     .pane {
-        grid-template-columns:1fr;
+        flex-direction: column;
     }
 }
 
@@ -90,6 +90,8 @@ select {
     border: 0;
     border-radius: 0;
     height: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .gridViewport.dragging {
@@ -164,6 +166,9 @@ select {
     gap: 12px 18px;
     overflow: auto;
     height: 100%;
+    flex: 0 0 auto;
+    margin-left: 0;
+    align-self: stretch;
 }
 
 @media (max-width: var(--clue-breakpoint)) {


### PR DESCRIPTION
## Summary
- add `--pane-gap` constant in `:root` and use it to remove spacing in the puzzle pane
- switch `.pane` to a flex layout so the grid expands and the clues stay to the right
- ensure clue panel width is constrained with flex rules on `.gridViewport` and `.clues`

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a23a316b2c83279d6799e8d5bc6571