### PR TITLE
Align clue pane flush to widget edge

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -4,12 +4,14 @@
     --border-radius: 10px;
     --cell: 44px;
     --gap: 4px;
-    --puzzle-max-size: 520px;
     --controls-breakpoint: 500px;
     --pane-breakpoint: 800px;
     --clue-breakpoint: 600px;
-    --widget-min-width: 800px;
+    --wrap-offset: 48px;
     --pane-gap: 0px;
+    --clue-track-size: max-content;
+    --clue-stack-track-size: 1fr;
+    --full-size: 100%;
 }
 
 * {
@@ -30,8 +32,10 @@ body {
     min-height: 100vh;
 }
 
+
 .wrap {
-    width: max(var(--widget-min-width), calc(100vw - 48px));
+    width: fit-content;
+    max-width: calc(100vw - var(--wrap-offset));
     background: rgba(255, 255, 255, .06);
     border: 1px solid rgba(255, 255, 255, .15);
     border-radius: 16px;
@@ -41,7 +45,7 @@ body {
     display: grid;
     grid-template-rows: auto 1fr auto;
     gap: 16px;
-    min-height: calc(100vh - 48px);
+    min-height: calc(100vh - var(--wrap-offset));
 }
 
 .hdr {
@@ -84,13 +88,14 @@ select {
 
 /* Viewport: keep scrolling/panning, but no panel look */
 .gridViewport {
-    max-width: min(var(--puzzle-max-size), 100%);
+    width: max-content;
+    max-width: var(--full-size);
     overflow: auto;
     background: transparent;
     border: 0;
     border-radius: 0;
-    height: 100%;
-    flex: 1 1 auto;
+    height: var(--full-size);
+    flex: 0 0 auto;
     min-width: 0;
 }
 
@@ -162,18 +167,20 @@ select {
 
 .clues {
     display: grid;
-    grid-template-columns:1fr 1fr;
+    grid-template-columns: var(--clue-track-size) var(--clue-track-size);
     gap: 12px 18px;
     overflow: auto;
-    height: 100%;
+    height: var(--full-size);
     flex: 0 0 auto;
     margin-left: 0;
     align-self: stretch;
+    width: max-content;
 }
 
 @media (max-width: var(--clue-breakpoint)) {
     .clues {
-        grid-template-columns:1fr;
+        grid-template-columns: var(--clue-stack-track-size);
+        width: var(--full-size);
     }
 }
 


### PR DESCRIPTION
## Summary
- Size the widget to its content so the clue list aligns with the right edge
- Constrain the grid viewport and clue columns with layout variables for a tighter fit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23c93ed3883279a27aefc5af38dfa