### PR TITLE
Ensure panes remain within widget boundary

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -83,10 +83,13 @@ select {
     min-height: 0;
     max-width: var(--full-size);
     overflow: hidden;
+    flex: 1 1 auto;
 }
 
 @media (max-width: var(--pane-breakpoint)) {
     .pane {
+        flex: 1 1 auto;
+        overflow: hidden;
         flex-direction: column;
     }
 }


### PR DESCRIPTION
## Summary
- Add `flex: 1 1 auto` and `overflow: hidden` to `.pane`
- Retain new properties in responsive media query

## Testing
- ⚠️ `npx playwright install chromium` *(failed: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a24dd5f1ec83279de7111454cbf5ef