### PR TITLE
Use literal breakpoints for responsive layout

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -4,9 +4,6 @@
     --border-radius: 10px;
     --cell: 44px;
     --gap: 4px;
-    --controls-breakpoint: 500px;
-    --pane-breakpoint: 800px;
-    --clue-breakpoint: 600px;
     --wrap-offset: 48px;
     --pane-gap: 18px;
     --clue-track-size: max-content;
@@ -86,7 +83,7 @@ select {
     flex: 1 1 auto;
 }
 
-@media (max-width: var(--pane-breakpoint)) {
+@media (max-width: 800px) {
     .pane {
         flex: 1 1 auto;
         overflow: hidden;
@@ -186,7 +183,7 @@ select {
     max-width: var(--full-size);
 }
 
-@media (max-width: var(--clue-breakpoint)) {
+@media (max-width: 600px) {
     .clues {
         grid-template-columns: var(--clue-stack-track-size);
         width: var(--full-size);
@@ -233,7 +230,7 @@ button.secondary {
     background: #334155;
 }
 
-@media (max-width: var(--controls-breakpoint)) {
+@media (max-width: 500px) {
     .controls {
         flex-direction: column;
     }


### PR DESCRIPTION
## Summary
- replace variable-based media queries with explicit pixel breakpoints for pane, clue stack, and control layout

## Testing
- `python - <<'PY'
from playwright.sync_api import sync_playwright
import os, json
path = "file://" + os.path.abspath("index.html")
outputs = []
with sync_playwright() as p:
    browser = p.chromium.launch()
    for width in [800, 600, 500]:
        page = browser.new_page(viewport={"width": width, "height": 1000})
        page.goto(path)
        pane_direction = page.evaluate("getComputedStyle(document.querySelector('.pane')).flexDirection")
        clues_cols = page.evaluate("getComputedStyle(document.querySelector('.clues')).gridTemplateColumns")
        clues_width = page.evaluate("getComputedStyle(document.querySelector('.clues')).width")
        controls_direction = page.evaluate("getComputedStyle(document.querySelector('.controls')).flexDirection")
        button_width = page.evaluate("getComputedStyle(document.querySelector('.controls button')).width")
        outputs.append({
            "width": width,
            "paneDirection": pane_direction,
            "clueColumns": clues_cols,
            "clueWidth": clues_width,
            "controlsDirection": controls_direction,
            "buttonWidth": button_width,
        })
    browser.close()
print(json.dumps(outputs, indent=2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac599cb9688327bdbbb348e8ba71db