### PR TITLE
Use literal breakpoints for responsive layout

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -4,9 +4,6 @@
     --border-radius: 10px;
     --cell: 44px;
     --gap: 4px;
-    --controls-breakpoint: 500px;
-    --pane-breakpoint: 800px;
-    --clue-breakpoint: 600px;
     --wrap-offset: 48px;
     --pane-gap: 18px;
     --clue-track-size: max-content;
@@ -86,11 +83,17 @@ select {
     flex: 1 1 auto;
 }
 
-@media (max-width: var(--pane-breakpoint)) {
+@media (max-width: 800px) {
     .pane {
         flex: 1 1 auto;
         overflow: hidden;
         flex-direction: column;
+    }
+    .gridViewport {
+        flex: 0 0 auto;
+    }
+    .clues {
+        flex: 1 1 auto;
     }
 }
 
@@ -186,7 +189,7 @@ select {
     max-width: var(--full-size);
 }
 
-@media (max-width: var(--clue-breakpoint)) {
+@media (max-width: 600px) {
     .clues {
         grid-template-columns: var(--clue-stack-track-size);
         width: var(--full-size);
@@ -233,7 +236,7 @@ button.secondary {
     background: #334155;
 }
 
-@media (max-width: var(--controls-breakpoint)) {
+@media (max-width: 500px) {
     .controls {
         flex-direction: column;
     }


### PR DESCRIPTION
## Summary
- replace variable-based media queries with explicit pixel breakpoints for pane, clue stack, and control layout
- keep grid visible on small screens by allowing clues to flex while preserving grid height

## Testing
- `python - <<'PY'
from playwright.sync_api import sync_playwright
import os, json
path = "file://" + os.path.abspath("index.html")
outputs = []
with sync_playwright() as p:
    browser = p.chromium.launch()
    for width in [800, 600, 500, 400, 375]:
        page = browser.new_page(viewport={"width": width, "height": 900})
        page.goto(path)
        bbox_grid = page.locator('#gridViewport').bounding_box()
        bbox_clues = page.locator('.clues').bounding_box()
        bbox_pane = page.locator('.pane').bounding_box()
        outputs.append({
            'width': width,
            'pane': bbox_pane,
            'gridViewport': bbox_grid,
            'clues': bbox_clues
        })
    browser.close()
print(json.dumps(outputs, indent=2))
PY`
- `python - <<'PY'
from playwright.sync_api import sync_playwright
import os, json
path = "file://" + os.path.abspath("index.html")
outputs = []
with sync_playwright() as p:
    browser = p.chromium.launch()
    for width in [800, 600, 500, 375]:
        page = browser.new_page(viewport={"width": width, "height": 1000})
        page.goto(path)
        pane_direction = page.evaluate("getComputedStyle(document.querySelector('.pane')).flexDirection")
        clues_cols = page.evaluate("getComputedStyle(document.querySelector('.clues')).gridTemplateColumns")
        controls_direction = page.evaluate("getComputedStyle(document.querySelector('.controls')).flexDirection")
        outputs.append({
            "width": width,
            "paneDirection": pane_direction,
            "clueColumns": clues_cols,
            "controlsDirection": controls_direction,
        })
    browser.close()
print(json.dumps(outputs, indent=2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac599cb9688327bdbbb348e8ba71db