### PR TITLE
style: improve clue panel responsiveness

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -170,11 +170,10 @@ select {
     gap: 12px 18px;
     overflow: auto;
     max-height: var(--full-size);
-    flex: 1 1 auto;
-    margin-left: 0;
-    align-self: stretch;
-    width: var(--full-size);
-    max-width: var(--full-size);
+    flex: 0 0 auto;
+    width: max-content;
+    margin-left: var(--pane-gap);
+    align-self: flex-start;
 }
 
 @media (max-width: var(--narrow-screen-width)) {
@@ -188,6 +187,9 @@ select {
 
     .clues {
         flex: 1 1 auto;
+        width: 100%;
+        margin-left: 0;
+        align-self: stretch;
     }
 }
 


### PR DESCRIPTION
## Summary
- limit clue panel width to content and align to top on wide screens
- expand clue panel to full width when screen narrower than 800px

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b2667233948327bbb63f2f3a7559b2