### PR TITLE
Add inline hint button for clues

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -198,6 +198,11 @@ select {
     font-size: 16px;
 }
 
+.hintControls {
+    display: inline-block;
+    padding: 0 2px;
+}
+
 ol {
     list-style: none;
     padding-left: 0;


### PR DESCRIPTION
## Summary
- Replace two-button hint controls with a single inline button that reveals a verbal hint then a letter before disabling
- Render hint controls inside a span and keep hint text on its own line
- Style hint controls as a compact inline block at the end of each clue

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b286051a2c8327b70991af2e379416