### PR TITLE
Enable vertical scrolling when puzzle panes stack

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -178,14 +178,17 @@ select {
 @media (max-width: var(--narrow-screen-width)) {
     .pane {
         flex-direction: column;
+        overflow-y: auto;
     }
 
     .gridViewport {
         flex: 0 0 auto;
+        height: auto;
+        overflow: visible;
     }
 
     .clues {
-        flex: 1 1 auto;
+        flex: 0 0 auto;
         width: 100%;
         margin-left: 0;
         align-self: stretch;


### PR DESCRIPTION
## Summary
- allow `.pane` to scroll vertically on narrow screens
- ensure grid viewport doesn't block scroll and clues render below the grid

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be5a288c5c8327b414e53f5be63298