### PR TITLE
Allow wrap to scroll on narrow screens

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -176,6 +176,11 @@ select {
 }
 
 @media (max-width: var(--narrow-screen-width)) {
+    .wrap {
+        height: auto;
+        overflow-y: auto;
+    }
+
     .pane {
         flex-direction: column;
         overflow-y: auto;


### PR DESCRIPTION
## Summary
- Enable vertical scrolling for the crossword wrapper on narrow screens by removing fixed height and hidden overflow.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be6cefefb48327a5d984d78296793b