### PR TITLE
Fix narrow-screen overflow handling

### DIFF
--- a/css/crossword.css
+++ b/css/crossword.css
@@ -175,15 +175,17 @@ select {
     align-self: flex-start;
 }
 
-@media (max-width: var(--narrow-screen-width)) {
+@media (max-width: 800px) {
     .wrap {
         height: auto;
         overflow-y: auto;
+        overflow-x: auto;
     }
 
     .pane {
         flex-direction: column;
         overflow-y: auto;
+        overflow-x: visible;
     }
 
     .gridViewport {


### PR DESCRIPTION
## Summary
- replace CSS media query with explicit `max-width: 800px`
- allow wrapping container to scroll horizontally on small screens
- ensure pane doesn't clip clues horizontally

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/llm_crossword/package.json')*
- `node - <<'NODE'
const {chromium} = require('/root/.npm/_npx/e41f203b7505f1fb/node_modules/playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage({ viewport: { width: 500, height: 800 } });
  await page.goto('file:///workspace/llm_crossword/index.html');
  const paneDirection = await page.evaluate(() => getComputedStyle(document.querySelector('.pane')).flexDirection);
  const wrapOverflowX = await page.evaluate(() => getComputedStyle(document.querySelector('.wrap')).overflowX);
  const wrapOverflowY = await page.evaluate(() => getComputedStyle(document.querySelector('.wrap')).overflowY);
  const paneOverflowX = await page.evaluate(() => getComputedStyle(document.querySelector('.pane')).overflowX);
  const paneOverflowY = await page.evaluate(() => getComputedStyle(document.querySelector('.pane')).overflowY);
  const gridTop = await page.evaluate(() => document.querySelector('.gridViewport').getBoundingClientRect().top);
  const cluesTop = await page.evaluate(() => document.querySelector('.clues').getBoundingClientRect().top);
  const scrollable = await page.evaluate(() => document.scrollingElement.scrollHeight > document.scrollingElement.clientHeight);
  console.log(JSON.stringify({paneDirection, wrapOverflowX, wrapOverflowY, paneOverflowX, paneOverflowY, gridTop, cluesTop, scrollable}, null, 2));
  await browser.close();
})();
NODE`
- `node - <<'NODE'
const {chromium} = require('/root/.npm/_npx/e41f203b7505f1fb/node_modules/playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage({ viewport: { width: 500, height: 200 } });
  await page.goto('file:///workspace/llm_crossword/index.html');
  const isScrollable = await page.evaluate(() => document.scrollingElement.scrollHeight > document.scrollingElement.clientHeight);
  console.log('scrollable', isScrollable);
  await browser.close();
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68bef0b1d5d0832797c1d92c880238e9